### PR TITLE
Switch to jmp and add Pale Moon support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://github.com/erichgoldman/add-url-to-window-title",
   "license": "GPL-2.0+",
   "version": "1.02",
+  "main": "lib/main.js",
   "icon": "icon.png",
   "permissions": {"private-browsing": true},
   "preferences": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "homepage": "https://github.com/erichgoldman/add-url-to-window-title",
   "license": "GPL-2.0+",
   "version": "1.02",
+  "engines": {
+        "firefox": ">=38.0a1",
+        "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
+   },
   "main": "lib/main.js",
   "icon": "icon.png",
   "permissions": {"private-browsing": true},


### PR DESCRIPTION
Could you please switch to [jpm](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx_to_jpm) and add [Pale Moon support](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md)?

I've built your add-on with jpm and it works well!