### PR TITLE
URL format preference

### DIFF
--- a/data/add-url-to-title.js
+++ b/data/add-url-to-title.js
@@ -28,11 +28,17 @@ var addURLToTitle = (function() {
 	var separatorString = '-';
 
 	/**
-	 * A preference which determines if the full URL should be shown (true) or
+	 * OBSOLETE - A preference which determines if the full URL should be shown (true) or
 	 * if only the hostname for the current web page should be shown (false).
 	 * @type {boolean}
 	 */
 	var showFullURL = false;
+
+	/**
+	  * A preference specifying URL format for the title.
+	  * @type {string}
+	  */
+	var urlFormat = '{protocol}://{hostname}{port}/';
 
 	/**
 	 * A preference which determines whether (true) or not (false) to show the
@@ -158,8 +164,9 @@ var addURLToTitle = (function() {
 		// prefs will be an array of the SimplePrefs for this extension's 
 		// branch, explicitly set them into the local variables
 		separatorString = prefs['separatorString'].trim();
+		urlFormat = prefs['urlFormat'];
 		showFullURL = prefs['showFullURL'];
-			
+
 		// Only run the update on change, set inside to prevent additional variable declaration
 		if(showFieldAttributes !== prefs['showFieldAttributes']){
 		
@@ -200,15 +207,26 @@ var addURLToTitle = (function() {
 		
 		// Default parameter value check
 		useOriginalTitle = typeof useOriginalTitle !== 'undefined' ? useOriginalTitle : false;
-			
-		if(showFullURL === false){
-			// Add a trailing slash after the hostname for security e.g., given 
-			// a malicious hostname like: "google.com-evilsite.com/" 
-			// will not match KeePass rule for "google.com/"
-			addedURL = document.location.hostname + '/';
-		}else{
-			addedURL = document.URL;
-		}
+		
+		// parse URL
+		var parser = document.createElement('a');
+		parser.href = document.URL;
+
+		// format URL
+		var replObj = {
+			'{protocol}': parser.protocol.slice(0,-1),
+			'{hostname}': parser.hostname,
+			'{port}': (parser.port != '') ? (':'+parser.port) : '',
+			'{path}': parser.pathname.substring(1),
+			'{args}': parser.search,
+			'{hash}': parser.hash
+		};
+		var re = new RegExp(Object.keys(replObj).join("|"),"gi");
+		addedURL = urlFormat.replace(re, function(matched){
+				return replObj[matched];
+		});
+		
+		parser = null;	
 		
 		// Used in observer to prevent unnecessary additional calls
 		lastTitleSetByAddon = true; 

--- a/data/add-url-to-title.js
+++ b/data/add-url-to-title.js
@@ -28,13 +28,6 @@ var addURLToTitle = (function() {
 	var separatorString = '-';
 
 	/**
-	 * OBSOLETE - A preference which determines if the full URL should be shown (true) or
-	 * if only the hostname for the current web page should be shown (false).
-	 * @type {boolean}
-	 */
-	var showFullURL = false;
-
-	/**
 	  * A preference specifying URL format for the title.
 	  * @type {string}
 	  */
@@ -48,8 +41,8 @@ var addURLToTitle = (function() {
 	var showFieldAttributes = false;
 
 	/**
-	 * The URL which will be added to the window title, determined by 
-	 * var showFullURL
+	 * The URL which will be added to the window title, formatted according
+	 * to urlFormat
 	 * @type {string}
 	 */
 	var addedURL = '';
@@ -165,7 +158,6 @@ var addURLToTitle = (function() {
 		// branch, explicitly set them into the local variables
 		separatorString = prefs['separatorString'].trim();
 		urlFormat = prefs['urlFormat'];
-		showFullURL = prefs['showFullURL'];
 
 		// Only run the update on change, set inside to prevent additional variable declaration
 		if(showFieldAttributes !== prefs['showFieldAttributes']){

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -2,6 +2,8 @@
 showFullURL_title = Show the full URL?
 showFullURL_description = Checked shows the full URL; Unchecked shows only the hostname
 
+urlFormat_title = URL Format
+urlFormat_description = Full URL format: {protocol}://{hostname}{port}/{path}{args}{hash}
 
 separatorString_title = Separator String
 separatorString_description = A string to be put between the original title and the URL (e.g., 'Title - URL' or 'Title :: URL')

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "permissions": {"private-browsing": true},
   "preferences": [
 	{
-        "name": "showFullURL",
-        "title": "Show the full URL?",
-        "description": "Checked shows the full URL; Unchecked shows only the hostname",
-        "type": "bool",
-        "value": true
+        "name": "urlFormat",
+        "title": "URL Format",
+        "description": "Full URL format: {protocol}://{hostname}{port}/{path}{args}{hash}",
+        "type": "string",
+        "value": "{protocol}://{hostname}{port}/"
     }
 	,
     {


### PR DESCRIPTION
I've updated the code to allow specifying URL pattern in preferences.

I did that in hope that KeePassXC would differentiate between http://domain.tld/foo and http://domain.tld/bar but it's not the case (yet?). Sometimes different services are hosted in a subdirectory and it's a bit annoying to manually select one login from all logins used by a domain each time. 

URL format inspired by https://chrome.google.com/webstore/detail/url-in-title/ignpacbgnbnkaiooknalneoeladjnfgb/related?hl=en

So it's up to you if you want to publish this change but it works. Note there is only English locale for the new option. Version number not updated.