### PR TITLE
manifest: Use browser_specific_settings for Firefox/Chrome compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,14 +29,11 @@
   "permissions": [
     "activeTab",
     "storage"
-  ]/* "applications" key is required by Firefox, but not accepted by Chrome,
-    * remove this comment when releasing for Firefox  
-  ,
-  "applications": {
+  ],
+  "browser_specific_settings": {
     "gecko": {
       "id": "autt@ericgoldman.name",
       "strict_min_version": "60.0"
     }
   }
-  */
 }


### PR DESCRIPTION
Since Firefox 48, it's possible to use browser_specific_settings instead
of applications. This way, the manifest works without modification
across most browsers.

It's also the correct key according to webextensions draft:
https://browserext.github.io/browserext/#dfn-browserspecificsettings