### PR TITLE
fix mutation observer on broken pages

### DIFF
--- a/managetitle.js
+++ b/managetitle.js
@@ -343,10 +343,14 @@ var addUrlToWindowTitle = (function() {
 			
 		});
 
-    var config = { attributes: true, childList: true, characterData: true };
-		var target = document.querySelector('head > title'); 
+	var config = { attributes: true, childList: true, characterData: true, subtree: true };
+		// in theory, the selector should be head > title, but some in some webpages with broken
+		// HTML the title tag is automatically moved to the body by the browser, and changes to it
+		// still change the actual website title. the title element also cannot validly appear
+		// anywhere else, so just selecting title is fine
+		var target = document.querySelector('title'); 
 
-		// Only run the observer on tabs that have a <head /> (e.g., not about:blank)
+		// Only run the observer on tabs that have a <title /> (e.g., not about:blank)
 		if(target !== null){ 
 			titleObserver.observe(target, config);
 		}


### PR DESCRIPTION
Some websites with broken HTML currently don't work correctly, since the MutationObserver watches for changes on the head > title element, but the title element still works from the browsers' perspective even when it is in the body.

One example is youtube right now for some videos: (i'm guessing a/b testing something):
![image](https://user-images.githubusercontent.com/2303841/101619911-2a65be80-3a14-11eb-8a6d-bfb783b00d91.png)

![image](https://user-images.githubusercontent.com/2303841/101619954-3a7d9e00-3a14-11eb-8598-cc3f862d071c.png)

![image](https://user-images.githubusercontent.com/2303841/101619963-3d788e80-3a14-11eb-8c8a-9f369f6419c4.png)

setting `document.querySelector("body>title").textContent = "foo"` updates the title on that page. 

The extension currently misses that website, causing no URL to appear in the window title. This PR fixes this on both firefox and chrome.


Minimal example:
```
<!doctype html>
<head>
</head>
<body>
<title>hello</title>
foo

<script>setTimeout(() => document.title="updated", 2000)</script></body>

```



---

In addition, this PR adds the subtree: true flag to the mutationobserver, since that is also required for some edge cases:

https://stackoverflow.com/a/22989490/2639190

or specifically: https://bugs.chromium.org/p/chromium/issues/detail?id=134322


---

There is one more edge case that this still doesn't handle: If no title element exists at all from the start, and then later document.title is set in JS, the browser auto-adds the title element to the head, but the mutation observer misses that change.